### PR TITLE
fix bug empty string with zero finshed

### DIFF
--- a/lib/PPersianRender.php
+++ b/lib/PPersianRender.php
@@ -228,7 +228,7 @@ class PPersianRender
             do {
                 $parts[] = mb_substr($string, 0, $string_length);
                 $string = mb_substr($string, $string_length);
-            } while(!empty($string));
+            } while(!empty($string) || (strlen($string) > 0));
         } else {
             $parts = array($string);
         }


### PR DESCRIPTION
 in mb_str_split() while loop, empty("0") is true and create bug for number
and string like 2000, 20, abc0, so use empty($string) and strlen($string)
for check empty.

examples 
2000 => 200 
20 => 2
abc0 => abc 